### PR TITLE
feat: enforce spring-return controls and retarder logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Simulateur-de-bus
+# Simulateur de bus urbain
+
+Application web immersive simulant la conduite d'un bus urbain avec des commandes tactiles/desktop optimisées, une transmission dynamique, des sons temps réel et une vue conducteur animée.
+
+## Lancement
+
+Ouvrir `index.html` dans un navigateur moderne (Chrome, Edge, Firefox, Safari). Aucune dépendance externe n'est nécessaire.
+
+## Commandes
+
+- **Volant** (gauche) : rotation réaliste ±450° par défaut (sélecteur 900→1440°), retour au centre progressif selon la vitesse.
+- **Frein** (slider vertical gauche) : ressort de rappel automatique, pré-course 1‑5 % dédiée au ralentisseur, frein de service >5 %, freinage d'urgence >90 %.
+- **Accélérateur** (slider vertical droit) : ressort de rappel automatique, détente kickdown vers 85‑88 % avec rétrogradages appuyés.
+- **Raccourci caméra** : bouton “Vue conducteur / Vue extérieure” ou touche `V`.
+
+## Points clés
+
+- Transmission automatique à rapports virtuels avec logique de kickdown et zones de régime 15 000‑25 000 tr/min.
+- Physique continue sensible à l'intensité des actions (accélérateur, frein, direction) avec gestion des jerks.
+- Vue conducteur 1ʳᵉ personne avec inertie de tête, roulis/tangage, vibrations et HUD complet (vitesse, régime, rapports, témoin ((K)) actif >15 km/h lorsque le ralentisseur agit, STOP, R, barres d'intensité).
+- Audio temps réel : moteur, ralentisseur (coupé ≤15 km/h), frein de service, crissement pneus, résonance et transitions kickdown.
+- Optimisation mobile : cibles tactiles ≥ 44 px, pointer events, scaling dynamique, prévention du scroll pendant les gestes.
+
+## Accessibilité
+
+- Commandes exposées en éléments `role="slider"` avec navigation clavier.
+- Lecture vocale des indicateurs HUD et retours visuels/haptiques (si supportés).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Simulateur de Bus Urbain</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <div id="app" class="app">
+      <div class="safe-area"></div>
+      <div class="scene-container">
+        <canvas id="scene-canvas" class="scene-canvas" aria-label="Vue conducteur du bus"></canvas>
+        <div class="hud" aria-live="polite">
+          <div class="hud-row primary">
+            <div class="hud-block">
+              <span class="hud-label">Vitesse</span>
+              <span id="hud-speed" class="hud-value">0 km/h</span>
+            </div>
+            <div class="hud-block">
+              <span class="hud-label">Régime</span>
+              <span id="hud-rpm" class="hud-value">0 tr/min</span>
+            </div>
+            <div class="hud-block hud-gear">
+              <span class="hud-label">Rapport</span>
+              <span id="hud-gear" class="hud-value">N</span>
+              <span id="hud-gear-trend" class="hud-trend"></span>
+            </div>
+          </div>
+          <div class="hud-row secondary">
+            <div class="hud-indicator" id="hud-k" aria-hidden="true">((K))</div>
+            <div class="hud-indicator" id="hud-stop">STOP</div>
+            <div class="hud-indicator" id="hud-retarder">R</div>
+          </div>
+          <div class="hud-bars">
+            <div class="hud-bar">
+              <span class="hud-label">Frein</span>
+              <div class="bar-track"><div id="hud-brake-bar" class="bar-fill"></div></div>
+            </div>
+            <div class="hud-bar">
+              <span class="hud-label">Accélérateur</span>
+              <div class="bar-track"><div id="hud-throttle-bar" class="bar-fill"></div></div>
+            </div>
+            <div class="hud-bar">
+              <span class="hud-label">Direction</span>
+              <div class="bar-track"><div id="hud-wheel-bar" class="bar-fill"></div></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="controls">
+        <div class="wheel-panel" aria-label="Volant du bus">
+          <div class="wheel-shadow"></div>
+          <div id="wheel" class="wheel" role="slider" aria-valuemin="-450" aria-valuemax="450" aria-valuenow="0" aria-label="Angle du volant" tabindex="0">
+            <div class="wheel-center"></div>
+            <div class="wheel-spoke spoke-0"></div>
+            <div class="wheel-spoke spoke-1"></div>
+            <div class="wheel-spoke spoke-2"></div>
+          </div>
+          <div class="wheel-indicator" id="wheel-angle-indicator">0°</div>
+          <div class="wheel-settings">
+            <label for="wheel-lock-select">Butée volant</label>
+            <select id="wheel-lock-select" aria-label="Plage de rotation du volant">
+              <option value="900" selected>900°</option>
+              <option value="1080">1080°</option>
+              <option value="1200">1200°</option>
+              <option value="1440">1440°</option>
+            </select>
+          </div>
+        </div>
+        <div class="pedal-panel">
+          <div class="slider" id="brake-slider" data-type="brake" role="slider" aria-label="Frein" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" tabindex="0">
+            <div class="slider-track">
+              <div class="slider-detent detent-pre"></div>
+              <div class="slider-detent detent-threshold"></div>
+              <div class="slider-fill"></div>
+              <div class="slider-handle" aria-hidden="true">
+                <span class="slider-value">0%</span>
+              </div>
+            </div>
+          </div>
+          <div class="slider" id="throttle-slider" data-type="throttle" role="slider" aria-label="Accélérateur" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" tabindex="0">
+            <div class="slider-track">
+              <div class="slider-detent detent-kickdown"></div>
+              <div class="slider-fill"></div>
+              <div class="slider-handle" aria-hidden="true">
+                <span class="slider-value">0%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <button id="camera-toggle" class="camera-toggle" type="button" aria-pressed="true">Vue conducteur</button>
+      <div class="touch-shield" id="touch-shield"></div>
+    </div>
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,142 @@
+import { clamp, lerp } from './utils.js';
+
+let audioContext;
+let masterGain;
+let engineOsc;
+let engineGain;
+let engineFilter;
+let noiseNode;
+let noiseGain;
+let brakeNoiseGain;
+let brakeNoiseFilter;
+let retarderNoiseGain;
+let retarderFilter;
+let tyreNoiseGain;
+let tyreFilter;
+let resonanceGain;
+let started = false;
+
+const createNoiseBuffer = (context) => {
+  const buffer = context.createBuffer(1, context.sampleRate * 1.5, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i += 1) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  return buffer;
+};
+
+const ensureAudio = async () => {
+  if (started) return;
+  if (!audioContext) {
+    audioContext = new (window.AudioContext || window.webkitAudioContext)({ latencyHint: 'interactive' });
+  }
+  if (audioContext.state === 'suspended') {
+    await audioContext.resume();
+  }
+
+  masterGain = audioContext.createGain();
+  masterGain.gain.value = 0.8;
+  masterGain.connect(audioContext.destination);
+
+  engineOsc = audioContext.createOscillator();
+  engineOsc.type = 'sawtooth';
+  engineGain = audioContext.createGain();
+  engineGain.gain.value = 0;
+  engineFilter = audioContext.createBiquadFilter();
+  engineFilter.type = 'bandpass';
+  engineFilter.Q.value = 1.6;
+  engineFilter.frequency.value = 200;
+
+  engineOsc.connect(engineGain);
+  engineGain.connect(engineFilter);
+  engineFilter.connect(masterGain);
+
+  const noiseBuffer = createNoiseBuffer(audioContext);
+  noiseNode = audioContext.createBufferSource();
+  noiseNode.buffer = noiseBuffer;
+  noiseNode.loop = true;
+  noiseGain = audioContext.createGain();
+  noiseGain.gain.value = 0.02;
+  noiseNode.connect(noiseGain);
+  noiseGain.connect(masterGain);
+
+  brakeNoiseGain = audioContext.createGain();
+  brakeNoiseGain.gain.value = 0;
+  brakeNoiseFilter = audioContext.createBiquadFilter();
+  brakeNoiseFilter.type = 'highpass';
+  brakeNoiseFilter.frequency.value = 1200;
+  brakeNoiseFilter.Q.value = 0.7;
+  noiseNode.connect(brakeNoiseFilter);
+  brakeNoiseFilter.connect(brakeNoiseGain);
+  brakeNoiseGain.connect(masterGain);
+
+  retarderNoiseGain = audioContext.createGain();
+  retarderNoiseGain.gain.value = 0;
+  retarderFilter = audioContext.createBiquadFilter();
+  retarderFilter.type = 'bandpass';
+  retarderFilter.frequency.value = 600;
+  retarderFilter.Q.value = 2.2;
+  noiseNode.connect(retarderFilter);
+  retarderFilter.connect(retarderNoiseGain);
+  retarderNoiseGain.connect(masterGain);
+
+  tyreNoiseGain = audioContext.createGain();
+  tyreNoiseGain.gain.value = 0;
+  tyreFilter = audioContext.createBiquadFilter();
+  tyreFilter.type = 'bandpass';
+  tyreFilter.frequency.value = 1400;
+  tyreFilter.Q.value = 4;
+  noiseNode.connect(tyreFilter);
+  tyreFilter.connect(tyreNoiseGain);
+  tyreNoiseGain.connect(masterGain);
+
+  resonanceGain = audioContext.createGain();
+  resonanceGain.gain.value = 0;
+  const resonanceFilter = audioContext.createBiquadFilter();
+  resonanceFilter.type = 'lowpass';
+  resonanceFilter.frequency.value = 320;
+  resonanceFilter.Q.value = 1.2;
+  noiseNode.connect(resonanceFilter);
+  resonanceFilter.connect(resonanceGain);
+  resonanceGain.connect(masterGain);
+
+  engineOsc.start();
+  noiseNode.start();
+  started = true;
+};
+
+export const unlockAudio = () => {
+  ensureAudio().catch(() => {});
+};
+
+export const updateAudio = (busState) => {
+  if (!started || !audioContext) return;
+  const rpm = busState.rpm;
+  const throttle = busState.throttle;
+  const gearFactor = busState.shift.active ? 0.6 : 1;
+  const load = busState.engineLoad;
+
+  const freq = lerp(70, 520, clamp((rpm - 6000) / 19000, 0, 1));
+  engineOsc.frequency.setTargetAtTime(freq, audioContext.currentTime, 0.05);
+  const filterTarget = lerp(280, 1400 + (busState.kickdownActive ? 160 : 0), clamp((rpm - 8000) / 17000, 0, 1));
+  engineFilter.frequency.setTargetAtTime(filterTarget, audioContext.currentTime, 0.06);
+  const gainValue = clamp(lerp(0.08, 0.28 + (busState.kickdownActive ? 0.05 : 0), throttle) * gearFactor + load * 0.22, 0, 0.46);
+  engineGain.gain.setTargetAtTime(gainValue, audioContext.currentTime, 0.08);
+
+  const serviceNoise = clamp(busState.serviceBrakeRatio * (busState.speed > 3 ? 1 : 0.6), 0, 1);
+  const hiss = clamp(busState.brakeHiss * (busState.speed > 4 ? 1 : 0.6), 0, 1);
+  brakeNoiseGain.gain.setTargetAtTime((serviceNoise * 0.35 + hiss * 0.18), audioContext.currentTime, 0.05);
+
+  const retarderLevel = clamp(busState.retarderIntensity * clamp((busState.speed * 3.6 - 15) / 45, 0, 1.1), 0, 1);
+  retarderNoiseGain.gain.setTargetAtTime(retarderLevel * 0.4, audioContext.currentTime, 0.08);
+  retarderFilter.frequency.setTargetAtTime(lerp(520, 1100, retarderLevel), audioContext.currentTime, 0.08);
+
+  const squeal = clamp(busState.brakeSqueal + busState.tyreSqueal * 0.6, 0, 1);
+  tyreNoiseGain.gain.setTargetAtTime(squeal * 0.5, audioContext.currentTime, 0.05);
+  tyreFilter.frequency.setTargetAtTime(lerp(900, 2300, clamp(busState.tyreSqueal, 0, 1)), audioContext.currentTime, 0.04);
+
+  resonanceGain.gain.setTargetAtTime(clamp(busState.resonance * 0.5, 0, 0.35), audioContext.currentTime, 0.2);
+
+  const ambience = clamp(busState.rumble * 0.06 + busState.speed * 0.002, 0, 0.12);
+  noiseGain.gain.setTargetAtTime(ambience, audioContext.currentTime, 0.2);
+};

--- a/src/controls.js
+++ b/src/controls.js
@@ -1,0 +1,475 @@
+import { clamp, lerp, wrapDegrees } from './utils.js';
+
+const DEFAULT_WHEEL_LOCK = 900; // degrees lock-to-lock
+const MIN_WHEEL_LOCK = 720;
+const MAX_WHEEL_LOCK = 1440;
+const HANDS_FREE_DELAY = 0.2; // seconds
+const BRAKE_DEADZONE = 0.01;
+const BRAKE_PRECOURSE = 0.05;
+const BRAKE_THRESHOLD = 0.05;
+const KICKDOWN_START = 0.85;
+const KICKDOWN_RELEASE = 0.82;
+const KICKDOWN_PASS = 0.88;
+const SPRING_RETURN_GAIN = 8.5;
+
+const getWheelLimit = (lockRange) => clamp(lockRange, MIN_WHEEL_LOCK, MAX_WHEEL_LOCK) / 2;
+
+const controlState = {
+  wheel: {
+    angle: 0,
+    lastAngle: 0,
+    velocity: 0,
+    lastVelocity: 0,
+    acceleration: 0,
+    target: 0,
+    pointerVelocity: 0,
+    pointerAcceleration: 0,
+    lastPointerVelocity: 0,
+    inputAggression: 0,
+    isInteracting: false,
+    pointerId: null,
+    pointerBaseAngle: 0,
+    pointerStartWheel: 0,
+    lockRange: DEFAULT_WHEEL_LOCK,
+    limit: getWheelLimit(DEFAULT_WHEEL_LOCK),
+    lastUpdate: performance.now(),
+    lastInteractionTime: performance.now(),
+  },
+  brake: {
+    value: 0,
+    lastValue: 0,
+    velocity: 0,
+    acceleration: 0,
+    target: 0,
+    isInteracting: false,
+    pointerId: null,
+    lastUpdate: performance.now(),
+    detentActive: false,
+    thresholdActive: false,
+    keyboardActive: false,
+    lastInteractionTime: performance.now(),
+  },
+  throttle: {
+    value: 0,
+    lastValue: 0,
+    velocity: 0,
+    acceleration: 0,
+    target: 0,
+    isInteracting: false,
+    pointerId: null,
+    lastUpdate: performance.now(),
+    kickdownLatched: false,
+    kickdownActive: false,
+    keyboardActive: false,
+    lastInteractionTime: performance.now(),
+  },
+  firstInteraction: false,
+  listeners: [],
+};
+
+const dom = {};
+
+const vibrate = (pattern) => {
+  if (navigator.vibrate) {
+    try {
+      navigator.vibrate(pattern);
+    } catch (err) {
+      /* ignore */
+    }
+  }
+};
+
+const pointerAngleFromEvent = (event, element) => {
+  const rect = element.getBoundingClientRect();
+  const cx = rect.left + rect.width / 2;
+  const cy = rect.top + rect.height / 2;
+  const dx = event.clientX - cx;
+  const dy = event.clientY - cy;
+  return (Math.atan2(dy, dx) * 180) / Math.PI;
+};
+
+const attachWheel = () => {
+  const wheel = dom.wheel;
+
+  const updateWheelVisual = () => {
+    wheel.style.transform = `rotate(${controlState.wheel.angle}deg)`;
+    wheel.setAttribute('aria-valuenow', controlState.wheel.angle.toFixed(0));
+    dom.wheelIndicator.textContent = `${controlState.wheel.angle.toFixed(0)}°`;
+  };
+
+  const clampWheelTarget = (value) => clamp(value, -controlState.wheel.limit, controlState.wheel.limit);
+
+  const pointerDown = (event) => {
+    if (controlState.wheel.pointerId !== null) return;
+    controlState.wheel.isInteracting = true;
+    controlState.wheel.pointerId = event.pointerId;
+    controlState.wheel.pointerBaseAngle = pointerAngleFromEvent(event, wheel);
+    controlState.wheel.pointerStartWheel = controlState.wheel.angle;
+    controlState.wheel.pointerVelocity = 0;
+    controlState.wheel.pointerAcceleration = 0;
+    controlState.wheel.lastPointerVelocity = 0;
+    controlState.firstInteraction = true;
+    controlState.wheel.lastInteractionTime = performance.now();
+    controlState.wheel.lastUpdate = performance.now();
+    wheel.setPointerCapture(event.pointerId);
+  };
+
+  const pointerMove = (event) => {
+    if (controlState.wheel.pointerId !== event.pointerId) return;
+    const pointerAngle = pointerAngleFromEvent(event, wheel);
+    const delta = wrapDegrees(pointerAngle - controlState.wheel.pointerBaseAngle);
+    const pointerScale = (controlState.wheel.lockRange / 1080) * 2.2;
+    const target = clampWheelTarget(controlState.wheel.pointerStartWheel + delta * pointerScale);
+    const now = performance.now();
+    const dt = Math.max(1, now - controlState.wheel.lastUpdate);
+    const velocity = ((target - controlState.wheel.target) / dt) * 1000;
+    controlState.wheel.pointerAcceleration = (velocity - controlState.wheel.pointerVelocity) / (dt / 1000);
+    controlState.wheel.pointerVelocity = velocity;
+    controlState.wheel.target = target;
+    controlState.wheel.lastUpdate = now;
+    controlState.wheel.lastInteractionTime = now;
+  };
+
+  const pointerUp = (event) => {
+    if (controlState.wheel.pointerId !== event.pointerId) return;
+    controlState.wheel.pointerId = null;
+    controlState.wheel.isInteracting = false;
+    controlState.wheel.pointerVelocity = 0;
+    controlState.wheel.pointerAcceleration = 0;
+    controlState.wheel.lastInteractionTime = performance.now();
+    wheel.releasePointerCapture(event.pointerId);
+  };
+
+  wheel.addEventListener('pointerdown', pointerDown);
+  window.addEventListener('pointermove', pointerMove);
+  window.addEventListener('pointerup', pointerUp);
+  window.addEventListener('pointercancel', pointerUp);
+
+  const keyStep = 12;
+  wheel.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowLeft' || event.key === 'a') {
+      controlState.wheel.target = clampWheelTarget(controlState.wheel.target - keyStep);
+      event.preventDefault();
+    }
+    if (event.key === 'ArrowRight' || event.key === 'd') {
+      controlState.wheel.target = clampWheelTarget(controlState.wheel.target + keyStep);
+      event.preventDefault();
+    }
+    if (['ArrowLeft', 'ArrowRight', 'a', 'd'].includes(event.key)) {
+      controlState.wheel.lastInteractionTime = performance.now();
+    }
+  });
+
+  wheel.addEventListener('keyup', (event) => {
+    if (['ArrowLeft', 'ArrowRight', 'a', 'd'].includes(event.key)) {
+      controlState.wheel.lastInteractionTime = performance.now();
+    }
+  });
+
+  controlState.listeners.push(updateWheelVisual);
+};
+
+const setWheelLockRange = (lockRange) => {
+  const sanitized = clamp(Math.round(lockRange / 30) * 30, MIN_WHEEL_LOCK, MAX_WHEEL_LOCK);
+  controlState.wheel.lockRange = sanitized;
+  controlState.wheel.limit = getWheelLimit(sanitized);
+  controlState.wheel.angle = clamp(controlState.wheel.angle, -controlState.wheel.limit, controlState.wheel.limit);
+  controlState.wheel.target = clamp(controlState.wheel.target, -controlState.wheel.limit, controlState.wheel.limit);
+  dom.wheel.setAttribute('aria-valuemin', (-controlState.wheel.limit).toFixed(0));
+  dom.wheel.setAttribute('aria-valuemax', controlState.wheel.limit.toFixed(0));
+  controlState.wheel.lastInteractionTime = performance.now();
+  if (dom.wheelLockSelect && dom.wheelLockSelect.value !== `${sanitized}`) {
+    dom.wheelLockSelect.value = `${sanitized}`;
+  }
+};
+
+const attachWheelLockSelector = () => {
+  if (!dom.wheelLockSelect) return;
+  dom.wheelLockSelect.value = `${DEFAULT_WHEEL_LOCK}`;
+  const handleChange = (event) => {
+    const value = parseInt(event.target.value, 10);
+    setWheelLockRange(Number.isFinite(value) ? value : DEFAULT_WHEEL_LOCK);
+    vibrate([8]);
+  };
+  dom.wheelLockSelect.addEventListener('change', handleChange);
+};
+
+const attachSlider = (element, state, options) => {
+  const handle = element.querySelector('.slider-handle');
+  const fill = element.querySelector('.slider-fill');
+  const valueLabel = element.querySelector('.slider-value');
+  const type = options.type;
+
+  const setVisual = () => {
+    fill.style.height = `${state.value * 100}%`;
+    const handleHeight = handle.offsetHeight || 56;
+    const pos = (1 - state.value) * (element.clientHeight - handleHeight - 28) + 14;
+    handle.style.top = `${pos}px`;
+    valueLabel.textContent = `${Math.round(state.value * 100)}%`;
+    element.setAttribute('aria-valuenow', Math.round(state.value * 100));
+  };
+
+  const sliderRect = () => element.getBoundingClientRect();
+
+  const pointerDown = (event) => {
+    if (state.pointerId !== null) return;
+    state.pointerId = event.pointerId;
+    state.isInteracting = true;
+    element.setPointerCapture(event.pointerId);
+    controlState.firstInteraction = true;
+    state.keyboardActive = false;
+    state.lastInteractionTime = performance.now();
+    state.lastUpdate = performance.now();
+    handleInput(event.clientY);
+  };
+
+  const pointerMove = (event) => {
+    if (state.pointerId !== event.pointerId) return;
+    handleInput(event.clientY);
+  };
+
+  const pointerUp = (event) => {
+    if (state.pointerId !== event.pointerId) return;
+    state.pointerId = null;
+    state.isInteracting = false;
+    state.keyboardActive = false;
+    state.target = 0;
+    state.lastInteractionTime = performance.now();
+    state.lastUpdate = performance.now();
+    element.releasePointerCapture(event.pointerId);
+  };
+
+  const handleInput = (clientY) => {
+    const rect = sliderRect();
+    const relative = clamp((clientY - rect.top) / rect.height, 0, 1);
+    const inverse = 1 - relative;
+    state.target = inverse;
+    const now = performance.now();
+    const dt = Math.max(1, now - state.lastUpdate);
+    const velocity = ((state.target - state.value) / dt) * 1000;
+    state.acceleration = (velocity - state.velocity) / (dt / 1000);
+    state.velocity = velocity;
+    state.lastUpdate = now;
+    state.lastInteractionTime = now;
+  };
+
+  element.addEventListener('pointerdown', pointerDown);
+  window.addEventListener('pointermove', pointerMove);
+  window.addEventListener('pointerup', pointerUp);
+  window.addEventListener('pointercancel', pointerUp);
+
+  const keyboardStep = options.keyboardStep ?? 0.04;
+  element.addEventListener('keydown', (event) => {
+    if (event.key === 'ArrowUp' || event.key === 'w') {
+      state.target = clamp(state.target + keyboardStep, 0, 1);
+      event.preventDefault();
+    }
+    if (event.key === 'ArrowDown' || event.key === 's') {
+      state.target = clamp(state.target - keyboardStep, 0, 1);
+      event.preventDefault();
+    }
+    if (['ArrowUp', 'ArrowDown', 'w', 's'].includes(event.key)) {
+      state.isInteracting = true;
+      state.keyboardActive = true;
+      state.lastInteractionTime = performance.now();
+    }
+  });
+
+  element.addEventListener('keyup', (event) => {
+    if (['ArrowUp', 'ArrowDown', 'w', 's'].includes(event.key)) {
+      state.isInteracting = false;
+      state.keyboardActive = false;
+      state.target = 0;
+      state.lastInteractionTime = performance.now();
+    }
+  });
+
+  controlState.listeners.push(setVisual);
+};
+
+const updateBrakeValue = (state, dt) => {
+  const prevValue = state.value;
+  const engaged = state.isInteracting || state.keyboardActive;
+  let target = engaged ? clamp(state.target, 0, 1) : 0;
+
+  let gain = engaged ? 7.2 : SPRING_RETURN_GAIN;
+  if (engaged && target <= BRAKE_PRECOURSE) {
+    const zone = clamp((target - BRAKE_DEADZONE) / Math.max(0.0001, BRAKE_PRECOURSE - BRAKE_DEADZONE), 0, 1);
+    target = BRAKE_DEADZONE + zone * (BRAKE_PRECOURSE - BRAKE_DEADZONE);
+    gain = lerp(2.8, 5.6, zone);
+  } else if (!engaged && state.value < BRAKE_PRECOURSE) {
+    gain = Math.max(gain, 7.5);
+  }
+
+  state.value += clamp(target - state.value, -gain * dt, gain * dt);
+  state.value = clamp(state.value, 0, 1);
+
+  const crossedPre = prevValue < BRAKE_DEADZONE && state.value >= BRAKE_DEADZONE;
+  const crossedThreshold = prevValue < BRAKE_THRESHOLD && state.value >= BRAKE_THRESHOLD;
+  if (crossedPre || crossedThreshold) {
+    vibrate([10]);
+  }
+
+  state.detentActive = state.value >= BRAKE_DEADZONE && state.value <= BRAKE_PRECOURSE;
+  state.thresholdActive = state.value >= BRAKE_THRESHOLD;
+};
+
+const updateThrottleValue = (state, dt) => {
+  const engaged = state.isInteracting || state.keyboardActive;
+  let target = engaged ? clamp(state.target, 0, 1) : 0;
+  const approachingKickdown = engaged && target >= KICKDOWN_START && target < KICKDOWN_PASS;
+  const crossingKickdown = engaged && target >= KICKDOWN_PASS;
+  const baseGain = engaged ? 8.2 : SPRING_RETURN_GAIN;
+  let gain = baseGain;
+
+  if (approachingKickdown && !state.kickdownLatched) {
+    const fraction = clamp((target - KICKDOWN_START) / (KICKDOWN_PASS - KICKDOWN_START), 0, 1);
+    const slowGain = lerp(2.6, baseGain, fraction);
+    gain = Math.min(gain, slowGain);
+  }
+
+  if (crossingKickdown) {
+    state.kickdownLatched = true;
+    gain = 10.2;
+  }
+
+  if (!engaged && state.value < KICKDOWN_RELEASE) {
+    state.kickdownLatched = false;
+  }
+
+  state.value += clamp(target - state.value, -gain * dt, gain * dt);
+  state.value = clamp(state.value, 0, 1);
+
+  const wasActive = state.kickdownActive;
+  state.kickdownActive = state.value >= KICKDOWN_PASS;
+  if (!engaged && state.value < KICKDOWN_RELEASE) {
+    state.kickdownActive = false;
+  }
+
+  if (state.kickdownActive && !wasActive) {
+    vibrate([20, 20, 20]);
+  }
+
+  if (!state.kickdownActive && wasActive && state.value < KICKDOWN_START) {
+    vibrate([12]);
+  }
+};
+
+const recenterProfiles = [
+  { maxSpeed: 0.2, stiffness: 0, damping: 7.2, maxRate: 140 },
+  { maxSpeed: 10, stiffness: 0.55, damping: 6.5, maxRate: 160 },
+  { maxSpeed: 20, stiffness: 1.1, damping: 6.8, maxRate: 200 },
+  { maxSpeed: 40, stiffness: 1.9, damping: 7.4, maxRate: 240 },
+  { maxSpeed: 70, stiffness: 2.8, damping: 7.9, maxRate: 300 },
+  { maxSpeed: Infinity, stiffness: 3.6, damping: 8.4, maxRate: 340 },
+];
+
+const getRecenterProfile = (speedKmh) => {
+  const profile = recenterProfiles.find((entry) => speedKmh <= entry.maxSpeed);
+  return profile || recenterProfiles[recenterProfiles.length - 1];
+};
+
+const updateWheel = (wheel, dt, busState) => {
+  const prevAngle = wheel.angle;
+  const prevVelocity = wheel.velocity;
+  wheel.target = clamp(wheel.target, -wheel.limit, wheel.limit);
+  const now = performance.now();
+  const speedKmh = busState.speed * 3.6;
+  const profile = getRecenterProfile(speedKmh);
+  const handsFree = !wheel.isInteracting && (now - wheel.lastInteractionTime) / 1000 > HANDS_FREE_DELAY;
+  const normalizedAngle = Math.min(1, Math.abs(wheel.angle) / Math.max(1, wheel.limit));
+  const pointerActivity = clamp(Math.abs(wheel.pointerAcceleration) / 2000, 0, 1);
+
+  if (wheel.isInteracting) {
+    wheel.inputAggression = lerp(wheel.inputAggression, pointerActivity, 0.12);
+    const lockFactor = clamp(wheel.lockRange / MAX_WHEEL_LOCK, 0.6, 1.1);
+    const maxRate = lerp(240, 660 * lockFactor, clamp(Math.abs(wheel.pointerVelocity) / 360, 0, 1));
+    const desired = clamp(wheel.target, -wheel.limit, wheel.limit);
+    const delta = clamp(desired - wheel.angle, -maxRate * dt, maxRate * dt);
+    wheel.angle += delta;
+    wheel.lastInteractionTime = now;
+  } else {
+    const stiffness = handsFree ? profile.stiffness * (0.7 + normalizedAngle * 0.6) : 0;
+    const damping = profile.damping;
+    const torque = -wheel.angle * stiffness - wheel.velocity * damping;
+    const torqueLimit = profile.maxRate * 6;
+    wheel.velocity += clamp(torque, -torqueLimit, torqueLimit) * dt;
+    wheel.velocity = clamp(wheel.velocity, -profile.maxRate, profile.maxRate);
+    wheel.angle += wheel.velocity * dt;
+    if (!handsFree) {
+      wheel.velocity *= 1 - clamp(dt * 5, 0, 0.6);
+    }
+    wheel.target = clamp(wheel.angle, -wheel.limit, wheel.limit);
+    wheel.inputAggression = lerp(wheel.inputAggression, 0, clamp(dt * 5, 0, 1));
+    if (Math.abs(wheel.angle) < 0.05 && Math.abs(wheel.velocity) < 0.25) {
+      wheel.angle = 0;
+      wheel.velocity = 0;
+    }
+  }
+
+  wheel.angle = clamp(wheel.angle, -wheel.limit, wheel.limit);
+  wheel.velocity = (wheel.angle - prevAngle) / dt;
+  wheel.acceleration = (wheel.velocity - prevVelocity) / dt;
+};
+
+const updateSliderKinematics = (state, dt) => {
+  state.velocity = (state.value - state.lastValue) / dt;
+  state.acceleration = (state.velocity - (state.lastVelocity ?? 0)) / dt;
+  state.lastVelocity = state.velocity;
+  state.lastValue = state.value;
+};
+
+export const initControls = () => {
+  dom.wheel = document.getElementById('wheel');
+  dom.wheelIndicator = document.getElementById('wheel-angle-indicator');
+  dom.brakeSlider = document.getElementById('brake-slider');
+  dom.throttleSlider = document.getElementById('throttle-slider');
+  dom.wheelLockSelect = document.getElementById('wheel-lock-select');
+
+  setWheelLockRange(DEFAULT_WHEEL_LOCK);
+  attachWheel();
+  attachWheelLockSelector();
+  attachSlider(dom.brakeSlider, controlState.brake, { type: 'brake' });
+  attachSlider(dom.throttleSlider, controlState.throttle, { type: 'throttle' });
+
+  return controlState;
+};
+
+export const updateControls = (dt, busState) => {
+  updateWheel(controlState.wheel, dt, busState);
+  updateBrakeValue(controlState.brake, dt);
+  updateThrottleValue(controlState.throttle, dt);
+  updateSliderKinematics(controlState.brake, dt);
+  updateSliderKinematics(controlState.throttle, dt);
+
+  controlState.listeners.forEach((cb) => cb());
+};
+
+export const getControlSnapshot = () => ({
+  wheelAngle: controlState.wheel.angle,
+  wheelVelocity: controlState.wheel.velocity,
+  wheelAcceleration: controlState.wheel.acceleration,
+  wheelAggression: controlState.wheel.inputAggression,
+  wheelLock: controlState.wheel.lockRange,
+  brake: controlState.brake.value,
+  brakeVelocity: controlState.brake.velocity,
+  brakeAcceleration: controlState.brake.acceleration,
+  brakeDetent: controlState.brake.detentActive,
+  brakeThreshold: controlState.brake.thresholdActive,
+  throttle: controlState.throttle.value,
+  throttleVelocity: controlState.throttle.velocity,
+  throttleAcceleration: controlState.throttle.acceleration,
+  kickdown: controlState.throttle.kickdownActive,
+  kickdownLatched: controlState.throttle.kickdownLatched,
+  userInteracting: controlState.firstInteraction,
+});
+
+export const setWheelExternal = (angle) => {
+  controlState.wheel.angle = clamp(angle, -controlState.wheel.limit, controlState.wheel.limit);
+  controlState.wheel.target = controlState.wheel.angle;
+};
+
+export const onFrameEnd = () => {
+  controlState.wheel.lastAngle = controlState.wheel.angle;
+  controlState.wheel.lastVelocity = controlState.wheel.velocity;
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,76 @@
+import { initControls, updateControls, getControlSnapshot, onFrameEnd } from './controls.js';
+import { updatePhysics, getBusState } from './physics.js';
+import { initRenderer, renderFrame, adjustRenderScale, setViewMode } from './render.js';
+import { unlockAudio, updateAudio } from './audio.js';
+
+const frameTimes = [];
+const MAX_HISTORY = 120;
+let lastTimestamp = performance.now();
+let audioUnlocked = false;
+let viewMode = 'cockpit';
+
+const controls = initControls();
+initRenderer();
+
+const cameraToggle = document.getElementById('camera-toggle');
+const touchShield = document.getElementById('touch-shield');
+
+touchShield.addEventListener('touchmove', (event) => {
+  event.preventDefault();
+}, { passive: false });
+
+const toggleView = () => {
+  viewMode = viewMode === 'cockpit' ? 'exterior' : 'cockpit';
+  setViewMode(viewMode);
+  cameraToggle.textContent = viewMode === 'cockpit' ? 'Vue conducteur' : 'Vue extérieure';
+  cameraToggle.setAttribute('aria-pressed', viewMode === 'cockpit');
+};
+
+cameraToggle.addEventListener('click', toggleView);
+document.addEventListener('keydown', (event) => {
+  if (event.key.toLowerCase() === 'v') {
+    toggleView();
+  }
+});
+
+const ensureAudioUnlocked = () => {
+  if (!audioUnlocked) {
+    audioUnlocked = true;
+    unlockAudio();
+  }
+};
+
+window.addEventListener('pointerdown', ensureAudioUnlocked, { once: true });
+window.addEventListener('keydown', ensureAudioUnlocked, { once: true });
+
+const clampDt = (dt) => {
+  if (Number.isNaN(dt) || !Number.isFinite(dt)) return 0.016;
+  return Math.min(Math.max(dt, 0.001), 0.05);
+};
+
+const updateFrameTimes = (frameMs) => {
+  frameTimes.push(frameMs);
+  if (frameTimes.length > MAX_HISTORY) {
+    frameTimes.shift();
+  }
+  const avg = frameTimes.reduce((acc, value) => acc + value, 0) / frameTimes.length;
+  adjustRenderScale(avg);
+};
+
+const loop = (timestamp) => {
+  const dt = clampDt((timestamp - lastTimestamp) / 1000);
+  lastTimestamp = timestamp;
+
+  const busState = getBusState();
+  updateControls(dt, busState);
+  const snapshot = getControlSnapshot();
+  updatePhysics(dt, snapshot);
+  renderFrame(busState, snapshot);
+  updateAudio(busState);
+  onFrameEnd();
+
+  updateFrameTimes(dt * 1000);
+  requestAnimationFrame(loop);
+};
+
+requestAnimationFrame(loop);

--- a/src/physics.js
+++ b/src/physics.js
@@ -1,0 +1,388 @@
+import { clamp, lerp } from './utils.js';
+
+const MASS = 13000;
+const WHEEL_RADIUS = 0.575;
+const WHEEL_BASE = 6.2;
+const TRACK_WIDTH = 2.6;
+const FINAL_DRIVE = 12.0;
+const ENGINE_IDLE = 6000;
+const ENGINE_MAX = 25000;
+const ENGINE_PEAK_TORQUE = 220;
+const DRAG_COEF = 0.42;
+const ROLLING_RESIST = 120;
+const BRAKE_FORCE_SERVICE = 150000;
+const BRAKE_FORCE_EMERGENCY = 240000;
+const CREEP_FORCE = 2800;
+const RETARDER_FORCE_MAX = 65000;
+const RETARDER_THRESHOLD_SPEED = 15 / 3.6;
+const BRAKE_HOLD_SPEED = 8 / 3.6;
+const DEFAULT_WHEEL_LOCK = 900;
+const BRAKE_DEADZONE = 0.01;
+const BRAKE_PRECOURSE = 0.05;
+
+const gearRatios = [0, 14.5, 9.6, 6.6, 4.7, 3.2, 2.4];
+const gearNames = ['N', '1', '2', '3', '4', '5', '6'];
+const upshiftRpm = [0, 17500, 18000, 18200, 18800, 19500, 20500];
+const downshiftRpm = [0, 11800, 12300, 12800, 13500, 14200, 15000];
+
+const randomRange = (min, max) => min + Math.random() * (max - min);
+
+const defaultState = {
+  time: 0,
+  speed: 0,
+  heading: 0,
+  yawRate: 0,
+  position: { x: 0, y: 0 },
+  acceleration: { long: 0, lat: 0 },
+  jerk: { long: 0, lat: 0 },
+  pitch: 0,
+  roll: 0,
+  heave: 0,
+  rpm: ENGINE_IDLE,
+  targetRpm: ENGINE_IDLE,
+  gearIndex: 1,
+  gearName: '1',
+  gearTrend: '',
+  shift: { active: false, timer: 0, phase: 'steady', target: 1, torqueFactor: 1 },
+  throttle: 0,
+  brake: 0,
+  serviceBrakeRatio: 0,
+  steering: {
+    wheelAngle: 0,
+    roadAngle: 0,
+    ratio: 20,
+  },
+  slip: 0,
+  tyreSqueal: 0,
+  brakeSqueal: 0,
+  brakeHiss: 0,
+  brakeHold: false,
+  retarder: false,
+  retarderForce: 0,
+  retarderIntensity: 0,
+  kIndicator: false,
+  stopLamp: false,
+  engineLoad: 0,
+  kickdownActive: false,
+  allowUpshiftTimer: 0,
+  kickdownLatchTimer: 0,
+  camera: {
+    pitch: 0,
+    roll: 0,
+    yaw: 0,
+    surge: 0,
+    sway: 0,
+    heave: 0,
+  },
+  resonance: 0,
+  rumble: 0,
+};
+
+const busState = structuredClone(defaultState);
+
+const wheelCircumference = 2 * Math.PI * WHEEL_RADIUS;
+
+const mapSteering = (wheelAngleDeg, lockRange = DEFAULT_WHEEL_LOCK) => {
+  const halfLock = Math.max(1, lockRange / 2);
+  const abs = Math.abs(wheelAngleDeg);
+  const fineFactor = clamp(Math.pow(abs / halfLock, 0.82), 0, 1);
+  const ratio = lerp(23, 12.4, fineFactor);
+  const roadAngleDeg = wheelAngleDeg / ratio;
+  return { roadAngleDeg, ratio };
+};
+
+const computeBrakeForces = (value, speed) => {
+  if (value <= BRAKE_DEADZONE) {
+    return { total: 0, service: 0, retarder: 0, retarderIntensity: 0 };
+  }
+
+  const speedKmh = speed * 3.6;
+  let retarderForce = 0;
+  let retarderIntensity = 0;
+  if (speed > RETARDER_THRESHOLD_SPEED && value > BRAKE_DEADZONE) {
+    if (value <= BRAKE_PRECOURSE) {
+      retarderIntensity = clamp((value - BRAKE_DEADZONE) / (BRAKE_PRECOURSE - BRAKE_DEADZONE), 0, 1);
+    } else {
+      retarderIntensity = 1;
+    }
+    const speedFactor = clamp(speedKmh / 90, 0, 1.15);
+    retarderForce = RETARDER_FORCE_MAX * retarderIntensity * speedFactor;
+  }
+
+  let serviceForce = 0;
+  if (value > BRAKE_PRECOURSE) {
+    const serviceValue = Math.min(value, 0.9);
+    const serviceNorm = clamp((serviceValue - BRAKE_PRECOURSE) / (0.9 - BRAKE_PRECOURSE), 0, 1);
+    serviceForce = lerp(0.14, 1, Math.pow(serviceNorm, 1.12)) * BRAKE_FORCE_SERVICE;
+    if (value > 0.9) {
+      const emergencyNorm = clamp((value - 0.9) / 0.1, 0, 1);
+      serviceForce = BRAKE_FORCE_SERVICE + emergencyNorm * (BRAKE_FORCE_EMERGENCY - BRAKE_FORCE_SERVICE);
+    }
+  }
+
+  if (speed < 2.2) {
+    const holdFactor = clamp((2.2 - speed) / 2.2, 0, 1);
+    serviceForce *= lerp(1, 1.18, holdFactor);
+  }
+
+  const total = serviceForce + retarderForce;
+  return { total, service: serviceForce, retarder: retarderForce, retarderIntensity: clamp(retarderIntensity, 0, 1) };
+};
+
+const computeDriveForce = (throttle, gearIndex, rpm, kickdown) => {
+  if (gearIndex === 0) {
+    return throttle * 1400;
+  }
+  const ratio = gearRatios[gearIndex];
+  const engineFactor = Math.pow(throttle, kickdown ? 1.18 : 1.32);
+  const highRpmFactor = lerp(0.58, kickdown ? 1.05 : 0.96, 1 - clamp((rpm - 14000) / 9000, 0, 1));
+  const torque = ENGINE_PEAK_TORQUE * engineFactor * highRpmFactor;
+  const wheelTorque = torque * ratio * FINAL_DRIVE * 0.92;
+  const wheelForce = wheelTorque / WHEEL_RADIUS;
+  const kickBoost = kickdown ? 1.55 : 1;
+  return wheelForce * kickBoost;
+};
+
+const updateTransmission = (dt, controls) => {
+  const { throttle, kickdown } = controls;
+  const wheelRpm = (busState.speed / wheelCircumference) * 60;
+  const gearRatio = gearRatios[busState.gearIndex] || 0;
+  let targetRpm = ENGINE_IDLE;
+  if (gearRatio > 0) {
+    targetRpm = clamp(wheelRpm * gearRatio * FINAL_DRIVE, ENGINE_IDLE, ENGINE_MAX);
+  } else {
+    targetRpm = ENGINE_IDLE + throttle * 6000;
+  }
+  busState.targetRpm = targetRpm;
+
+  busState.allowUpshiftTimer = Math.max(0, busState.allowUpshiftTimer - dt);
+  busState.kickdownLatchTimer = Math.max(0, busState.kickdownLatchTimer - dt);
+  const wasKickdown = busState.kickdownActive;
+  if (kickdown) {
+    busState.kickdownActive = true;
+  } else if (!busState.shift.active || busState.shift.direction !== 'down') {
+    busState.kickdownActive = false;
+  }
+  if (!kickdown && wasKickdown) {
+    busState.kickdownLatchTimer = randomRange(0.2, 0.4);
+  }
+
+  if (busState.shift.active) {
+    busState.shift.timer -= dt;
+    if (busState.shift.phase === 'latency') {
+      const progress = clamp(1 - busState.shift.timer / busState.shift.latency, 0, 1);
+      busState.shift.torqueFactor = lerp(1, 0.25, progress);
+      if (busState.shift.timer <= 0) {
+        busState.gearIndex = busState.shift.target;
+        busState.gearName = gearNames[busState.gearIndex];
+        busState.shift.phase = 'engage';
+        busState.shift.timer = busState.shift.engage;
+        busState.shift.torqueFactor = 0.35;
+        busState.gearTrend = busState.shift.direction === 'up' ? '↑' : '↓';
+      }
+    } else if (busState.shift.phase === 'engage') {
+      const progress = clamp(1 - busState.shift.timer / busState.shift.engage, 0, 1);
+      busState.shift.torqueFactor = lerp(0.35, 1, progress);
+      if (busState.shift.timer <= 0) {
+        busState.shift.active = false;
+        busState.shift.phase = 'steady';
+        busState.shift.torqueFactor = 1;
+        busState.gearTrend = '';
+      }
+    }
+  } else {
+    busState.shift.torqueFactor = lerp(busState.shift.torqueFactor, 1, dt * 4);
+  }
+
+  if (busState.shift.active) {
+    return;
+  }
+
+  const currentGear = busState.gearIndex;
+  const rpm = busState.rpm;
+  const upshiftBlocked = kickdown || busState.allowUpshiftTimer > 0 || busState.kickdownLatchTimer > 0;
+  const canUpshift = currentGear < gearRatios.length - 1 && !upshiftBlocked;
+  const canDownshift = currentGear > 1;
+
+  const requestShift = (target, direction, latencyRange, engageRange = [0.14, 0.2], torqueDip = 0.65) => {
+    if (target === currentGear) return;
+    busState.shift.active = true;
+    busState.shift.phase = 'latency';
+    busState.shift.target = target;
+    busState.shift.direction = direction;
+    busState.shift.latency = randomRange(latencyRange[0], latencyRange[1]);
+    busState.shift.engage = randomRange(engageRange[0], engageRange[1]);
+    busState.shift.timer = busState.shift.latency;
+    busState.shift.torqueFactor = torqueDip;
+  };
+
+  if (kickdown && canDownshift) {
+    const drop = throttle > 0.95 ? 2 : 1;
+    const target = Math.max(1, currentGear - drop);
+    if (target !== currentGear) {
+      requestShift(target, 'down', [0.3, 0.5], [0.24, 0.32], 0.5);
+      busState.kickdownActive = true;
+      busState.allowUpshiftTimer = Math.max(busState.allowUpshiftTimer, randomRange(0.45, 0.55));
+      busState.kickdownLatchTimer = Math.max(busState.kickdownLatchTimer, randomRange(0.35, 0.5));
+      return;
+    }
+  }
+
+  if (canUpshift && rpm > upshiftRpm[currentGear] && throttle < 0.98) {
+    requestShift(currentGear + 1, 'up', [0.12, 0.18]);
+    return;
+  }
+
+  if (canDownshift && (rpm < downshiftRpm[currentGear] || (rpm < downshiftRpm[currentGear] + 800 && throttle > 0.5))) {
+    requestShift(currentGear - 1, 'down', [0.16, 0.24], [0.16, 0.22], 0.58);
+    busState.allowUpshiftTimer = Math.max(busState.allowUpshiftTimer, randomRange(0.18, 0.28));
+    return;
+  }
+};
+
+const updateCamera = (dt) => {
+  const lat = busState.acceleration.lat;
+  const lon = busState.acceleration.long;
+  const jerkLat = busState.jerk.lat;
+  const jerkLong = busState.jerk.long;
+
+  const targetRoll = clamp(-lat * 0.9 - jerkLat * 0.04, -6, 6);
+  const targetPitch = clamp(-lon * 0.45 - jerkLong * 0.08, -5.5, 5.5);
+
+  busState.camera.roll = lerp(busState.camera.roll, targetRoll, clamp(dt * 5, 0, 1));
+  busState.camera.pitch = lerp(busState.camera.pitch, targetPitch, clamp(dt * 4, 0, 1));
+  busState.camera.yaw = lerp(busState.camera.yaw, clamp(busState.yawRate * 28, -4, 4), clamp(dt * 3, 0, 1));
+  const swayTarget = clamp(lat * 0.08 + jerkLat * 0.02, -0.4, 0.4);
+  busState.camera.sway = lerp(busState.camera.sway, swayTarget, clamp(dt * 5, 0, 1));
+  const surgeTarget = clamp(-lon * 0.05 - jerkLong * 0.02, -0.45, 0.35);
+  busState.camera.surge = lerp(busState.camera.surge, surgeTarget, clamp(dt * 5, 0, 1));
+  busState.camera.heave = lerp(busState.camera.heave, busState.heave, clamp(dt * 3, 0, 1));
+};
+
+export const updatePhysics = (dt, controls) => {
+  busState.time += dt;
+  busState.throttle = controls.throttle;
+  busState.brake = controls.brake;
+
+  updateTransmission(dt, controls);
+
+  const wheelMap = mapSteering(controls.wheelAngle, controls.wheelLock ?? DEFAULT_WHEEL_LOCK);
+  const roadAngle = (wheelMap.roadAngleDeg * Math.PI) / 180;
+  const yawRateTarget = busState.speed * Math.tan(roadAngle) / WHEEL_BASE;
+
+  const steerAggression = clamp(Math.abs(controls.wheelAcceleration) / 800, 0, 1);
+  const latImpulse = clamp(Math.abs(controls.wheelVelocity) / 300, 0, 1);
+  const brakeAggression = clamp(Math.abs(controls.brakeAcceleration) * 0.35, 0, 1);
+
+  const yawBlend = clamp(dt * (2 + latImpulse * 6), 0, 1);
+  busState.yawRate = lerp(busState.yawRate, yawRateTarget, yawBlend);
+  busState.heading += busState.yawRate * dt;
+  busState.position.x += Math.cos(busState.heading) * busState.speed * dt;
+  busState.position.y += Math.sin(busState.heading) * busState.speed * dt;
+
+  const lateralAccel = busState.speed * busState.yawRate + steerAggression * 1.8 + latImpulse * 0.9;
+
+  const brakeData = computeBrakeForces(busState.brake, busState.speed);
+  const driveForceRaw = computeDriveForce(busState.throttle, busState.gearIndex, busState.targetRpm, controls.kickdown);
+  const shiftFactor = busState.shift.torqueFactor ?? 1;
+  const driveForce = driveForceRaw * shiftFactor;
+
+  const dragForce = DRAG_COEF * busState.speed * busState.speed;
+  const rollingForce = ROLLING_RESIST + busState.speed * 65;
+
+  let longForce = driveForce - dragForce - rollingForce;
+
+  if (busState.speed < 2.2) {
+    const creep = clamp(1 - busState.speed / 2.2, 0, 1) * CREEP_FORCE;
+    const creepFactor = busState.brake > BRAKE_DEADZONE ? 0.25 : 1;
+    longForce += creep * creepFactor;
+  }
+
+  longForce -= brakeData.total;
+
+  let accelerationLong = longForce / MASS;
+
+  const holdProgress = clamp((BRAKE_HOLD_SPEED - busState.speed) / BRAKE_HOLD_SPEED, 0, 1);
+  const holdThreshold = lerp(0.32, 0.48, holdProgress);
+  if (holdProgress > 0 && busState.brake > holdThreshold) {
+    busState.brakeHold = true;
+    const clampTarget = lerp(-0.9, -3.1, holdProgress);
+    accelerationLong = Math.min(accelerationLong, clampTarget);
+  } else {
+    busState.brakeHold = false;
+  }
+
+  const prevSpeed = busState.speed;
+  busState.speed = clamp(busState.speed + accelerationLong * dt, 0, 38);
+  if (busState.brakeHold && busState.speed < 0.05) {
+    busState.speed = 0;
+  }
+  if (busState.speed <= 0.01) {
+    busState.speed = 0;
+  }
+
+  const actualAccelLong = (busState.speed - prevSpeed) / dt;
+
+  const prevAccelLong = busState.acceleration.long;
+  const prevAccelLat = busState.acceleration.lat;
+
+  busState.acceleration.long = actualAccelLong;
+  busState.acceleration.lat = lerp(prevAccelLat, lateralAccel, clamp(dt * 6, 0, 1));
+
+  busState.jerk.long = (busState.acceleration.long - prevAccelLong) / dt;
+  busState.jerk.lat = (busState.acceleration.lat - prevAccelLat) / dt;
+
+  busState.pitch = lerp(busState.pitch, clamp(-busState.acceleration.long * 1.3 - busState.jerk.long * 0.05, -8, 6), clamp(dt * 4, 0, 1));
+  busState.roll = lerp(busState.roll, clamp(busState.acceleration.lat * 1.1 + steerAggression * 2.2, -7, 7), clamp(dt * 5, 0, 1));
+  busState.heave = lerp(busState.heave, clamp(-busState.acceleration.long * 0.06 + Math.sin(busState.time * 12) * 0.02, -0.2, 0.2), clamp(dt * 2, 0, 1));
+
+  busState.steering.wheelAngle = controls.wheelAngle;
+  busState.steering.roadAngle = wheelMap.roadAngleDeg;
+  busState.steering.ratio = wheelMap.ratio;
+
+  busState.engineLoad = clamp(driveForceRaw / (computeDriveForce(1, busState.gearIndex, busState.targetRpm, controls.kickdown) + 0.001), 0, 1);
+
+  const rpmResponse = busState.shift.active ? lerp(busState.targetRpm, busState.targetRpm * 0.82, 0.3) : busState.targetRpm;
+  busState.rpm = lerp(busState.rpm, rpmResponse, clamp(dt * (controls.kickdown ? 7 : 5), 0, 1));
+
+  if (busState.shift.active && busState.shift.phase === 'latency') {
+    busState.rpm *= 0.98;
+  }
+
+  busState.stopLamp = busState.brake > 0.9 || busState.brakeHold;
+
+  const prevK = busState.kIndicator;
+  const retarderActive = brakeData.retarder > 1;
+  busState.retarder = retarderActive;
+  busState.retarderForce = brakeData.retarder;
+  busState.retarderIntensity = brakeData.retarderIntensity;
+  busState.kIndicator = retarderActive;
+
+  if (busState.kIndicator && !prevK) {
+    busState.resonance = 0.8;
+  }
+
+  busState.tyreSqueal = clamp(
+    Math.max(Math.abs(busState.jerk.lat) * 0.12, Math.abs(busState.acceleration.lat) * 0.08) * (busState.speed > 5 ? 1 : 0) +
+      brakeAggression * 0.2 * (busState.speed > 6 ? 1 : 0),
+    0,
+    1
+  );
+  const serviceShare = brakeData.service / Math.max(BRAKE_FORCE_SERVICE, 1);
+  const retarderShare = brakeData.retarderIntensity;
+  busState.serviceBrakeRatio = clamp(serviceShare, 0, 1);
+  const retarderNoise = retarderShare * clamp((busState.speed - RETARDER_THRESHOLD_SPEED) / 20, 0, 1);
+  busState.brakeHiss = clamp(serviceShare * (busState.speed > 3 ? 1 : 0.5) + retarderNoise * 0.45, 0, 1);
+  busState.brakeSqueal = clamp(serviceShare * (busState.speed > 4 ? 1 : 0.6) + brakeAggression * 0.45, 0, 1);
+
+  busState.rumble = lerp(busState.rumble, clamp(busState.speed / 30, 0, 1) + Math.abs(busState.acceleration.long) * 0.05, clamp(dt * 2, 0, 1));
+  busState.resonance = lerp(busState.resonance, 0, clamp(dt * 1.4, 0, 1));
+
+  updateCamera(dt);
+};
+
+export const getBusState = () => busState;
+
+export const resetPhysics = () => {
+  Object.assign(busState, structuredClone(defaultState));
+};

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,227 @@
+import { clamp, lerp } from './utils.js';
+
+const hud = {};
+const renderState = {
+  canvas: null,
+  ctx: null,
+  renderScale: 1,
+  dpr: 1,
+  viewMode: 'cockpit',
+  lastWidth: 0,
+  lastHeight: 0,
+};
+
+export const initRenderer = () => {
+  renderState.canvas = document.getElementById('scene-canvas');
+  renderState.ctx = renderState.canvas.getContext('2d');
+  renderState.dpr = window.devicePixelRatio || 1;
+  hud.speed = document.getElementById('hud-speed');
+  hud.rpm = document.getElementById('hud-rpm');
+  hud.gear = document.getElementById('hud-gear');
+  hud.gearTrend = document.getElementById('hud-gear-trend');
+  hud.k = document.getElementById('hud-k');
+  hud.stop = document.getElementById('hud-stop');
+  hud.retarder = document.getElementById('hud-retarder');
+  hud.brakeBar = document.getElementById('hud-brake-bar');
+  hud.throttleBar = document.getElementById('hud-throttle-bar');
+  hud.wheelBar = document.getElementById('hud-wheel-bar');
+
+  resizeCanvas();
+  window.addEventListener('resize', resizeCanvas);
+};
+
+const resizeCanvas = () => {
+  const rect = renderState.canvas.getBoundingClientRect();
+  const { width, height } = rect;
+  renderState.lastWidth = width;
+  renderState.lastHeight = height;
+  const scale = renderState.renderScale;
+  renderState.canvas.width = Math.max(1, width * renderState.dpr * scale);
+  renderState.canvas.height = Math.max(1, height * renderState.dpr * scale);
+  renderState.ctx.setTransform(renderState.dpr * scale, 0, 0, renderState.dpr * scale, 0, 0);
+};
+
+export const setViewMode = (mode) => {
+  renderState.viewMode = mode;
+};
+
+export const adjustRenderScale = (avgFrame) => {
+  const target = 16.7;
+  if (avgFrame > target * 1.15 && renderState.renderScale > 0.75) {
+    renderState.renderScale = Math.max(0.6, renderState.renderScale - 0.05);
+    resizeCanvas();
+  } else if (avgFrame < target * 0.9 && renderState.renderScale < 1) {
+    renderState.renderScale = Math.min(1, renderState.renderScale + 0.05);
+    resizeCanvas();
+  }
+};
+
+const updateHud = (busState, controls) => {
+  const speedKmh = busState.speed * 3.6;
+  hud.speed.textContent = `${speedKmh.toFixed(0)} km/h`;
+  hud.rpm.textContent = `${Math.round(busState.rpm).toLocaleString('fr-FR')} tr/min`;
+  hud.gear.textContent = busState.gearName;
+  hud.gearTrend.dataset.trend = busState.gearTrend || '';
+  hud.brakeBar.style.width = `${clamp(controls.brake, 0, 1) * 100}%`;
+  hud.throttleBar.style.width = `${clamp(controls.throttle, 0, 1) * 100}%`;
+  const wheelLimit = Math.max(1, (controls.wheelLock ?? 900) / 2);
+  hud.wheelBar.style.width = `${clamp(Math.abs(controls.wheelAngle) / wheelLimit, 0, 1) * 100}%`;
+
+  hud.k.classList.toggle('active', busState.kIndicator);
+  hud.stop.classList.toggle('active', busState.stopLamp);
+  hud.retarder.classList.toggle('active', busState.retarder);
+};
+
+const drawCockpit = (ctx, width, height, busState) => {
+  ctx.save();
+  ctx.clearRect(0, 0, width, height);
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, height);
+  gradient.addColorStop(0, '#1b2535');
+  gradient.addColorStop(0.5, '#0a0d14');
+  gradient.addColorStop(1, '#05070b');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const horizonY = height * 0.45 + busState.camera.surge * 30;
+  const roadWidth = width * 0.7;
+  const laneOffset = busState.camera.sway * 60;
+
+  ctx.fillStyle = '#1a1f27';
+  ctx.beginPath();
+  ctx.moveTo(-width * 0.2 + laneOffset, horizonY);
+  ctx.lineTo(width * 0.2 + laneOffset, height);
+  ctx.lineTo(width * 0.8 + laneOffset, height);
+  ctx.lineTo(width * 0.4 + laneOffset, horizonY);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = '#2a303c';
+  ctx.beginPath();
+  ctx.moveTo(width * 0.4 + laneOffset, horizonY);
+  ctx.lineTo(width * 0.8 + laneOffset, height);
+  ctx.lineTo(width * 0.85 + laneOffset, height);
+  ctx.lineTo(width * 0.45 + laneOffset, horizonY);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.strokeStyle = '#f5faff';
+  ctx.lineWidth = 4;
+  ctx.setLineDash([30, 30]);
+  ctx.beginPath();
+  ctx.moveTo(width * 0.5 + laneOffset, horizonY);
+  ctx.lineTo(width * 0.6 + laneOffset, height);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  const dashTop = height * 0.58;
+  ctx.fillStyle = '#0c121a';
+  ctx.beginPath();
+  ctx.roundRect(width * 0.05, dashTop, width * 0.9, height * 0.42, 28);
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.fillStyle = 'rgba(82,168,255,0.08)';
+  ctx.beginPath();
+  ctx.roundRect(width * 0.12, dashTop + 26, width * 0.36, height * 0.18, 18);
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255,255,255,0.06)';
+  ctx.beginPath();
+  ctx.roundRect(width * 0.54, dashTop + 18, width * 0.36, height * 0.2, 18);
+  ctx.fill();
+
+  ctx.fillStyle = 'rgba(255,255,255,0.04)';
+  ctx.beginPath();
+  ctx.roundRect(width * 0.32, dashTop + 140, width * 0.24, height * 0.16, 16);
+  ctx.fill();
+
+  const rpmBarWidth = lerp(width * 0.18, width * 0.26, clamp((busState.rpm - 6000) / 19000, 0, 1));
+  ctx.fillStyle = 'rgba(82,168,255,0.45)';
+  ctx.fillRect(width * 0.58, dashTop + 40, rpmBarWidth, 12);
+  ctx.fillStyle = 'rgba(30,122,255,0.7)';
+  ctx.fillRect(width * 0.58, dashTop + 60, rpmBarWidth * clamp(busState.throttle, 0, 1), 10);
+
+  const brakeBar = width * 0.2 * clamp(busState.brake, 0, 1);
+  ctx.fillStyle = 'rgba(255,79,109,0.6)';
+  ctx.fillRect(width * 0.18, dashTop + 64, brakeBar, 8);
+
+  ctx.restore();
+};
+
+const drawExterior = (ctx, width, height, busState) => {
+  ctx.save();
+  ctx.clearRect(0, 0, width, height);
+  const sky = ctx.createLinearGradient(0, 0, 0, height);
+  sky.addColorStop(0, '#0f1e33');
+  sky.addColorStop(1, '#05070b');
+  ctx.fillStyle = sky;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = '#1a202b';
+  ctx.fillRect(0, height * 0.6, width, height * 0.4);
+
+  const busX = width * 0.5 + Math.sin(busState.time * 0.6) * 10;
+  const busY = height * 0.65;
+  const busWidth = width * 0.36;
+  const busHeight = height * 0.22;
+
+  ctx.save();
+  ctx.translate(busX, busY);
+  ctx.rotate(busState.roll * (Math.PI / 180) * 0.2);
+  ctx.translate(-busWidth / 2, -busHeight / 2);
+
+  ctx.fillStyle = '#1d2a3a';
+  ctx.fillRect(0, 0, busWidth, busHeight);
+  ctx.fillStyle = '#25364d';
+  ctx.fillRect(busWidth * 0.05, busHeight * 0.15, busWidth * 0.9, busHeight * 0.4);
+  ctx.fillStyle = '#1f2d40';
+  ctx.fillRect(busWidth * 0.05, busHeight * 0.56, busWidth * 0.9, busHeight * 0.34);
+  ctx.fillStyle = '#101822';
+  ctx.fillRect(busWidth * 0.07, busHeight * 0.64, busWidth * 0.18, busHeight * 0.15);
+  ctx.fillRect(busWidth * 0.75, busHeight * 0.64, busWidth * 0.18, busHeight * 0.15);
+
+  ctx.fillStyle = 'rgba(82,168,255,0.75)';
+  const rpmBar = clamp((busState.rpm - 6000) / 19000, 0, 1);
+  ctx.fillRect(busWidth * 0.12, busHeight * 0.18, busWidth * 0.22, busHeight * 0.12 * rpmBar);
+  ctx.restore();
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.1)';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.arc(busX - busWidth * 0.3, busY + busHeight * 0.4, busWidth * 0.2, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(busX + busWidth * 0.3, busY + busHeight * 0.4, busWidth * 0.2, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.restore();
+};
+
+const applyCameraTransform = (busState) => {
+  const { canvas } = renderState;
+  const pitch = busState.camera.pitch * 0.65;
+  const roll = busState.camera.roll * 0.7;
+  const yaw = busState.camera.yaw * 0.8;
+  const surge = busState.camera.surge * 30;
+  const sway = busState.camera.sway * 40;
+  const heave = busState.camera.heave * 26;
+  canvas.style.transform = `translate3d(${sway.toFixed(2)}px, ${(heave + surge).toFixed(2)}px, 0) rotateX(${pitch.toFixed(3)}deg) rotateY(${yaw.toFixed(3)}deg) rotateZ(${roll.toFixed(3)}deg)`;
+};
+
+export const renderFrame = (busState, controls) => {
+  if (!renderState.ctx) return;
+  const width = renderState.lastWidth;
+  const height = renderState.lastHeight;
+  if (renderState.viewMode === 'cockpit') {
+    drawCockpit(renderState.ctx, width, height, busState);
+    applyCameraTransform(busState);
+  } else {
+    drawExterior(renderState.ctx, width, height, busState);
+    renderState.canvas.style.transform = 'none';
+  }
+
+  updateHud(busState, controls);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,41 @@
+export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+export const lerp = (a, b, t) => a + (b - a) * t;
+
+export const smoothDamp = (current, target, velocityRef, smoothTime, maxSpeed, deltaTime) => {
+  smoothTime = Math.max(0.0001, smoothTime);
+  const omega = 2 / smoothTime;
+  const x = omega * deltaTime;
+  const exp = 1 / (1 + x + 0.48 * x * x + 0.235 * x * x * x);
+  let change = current - target;
+  const originalTo = target;
+  const maxChange = maxSpeed * smoothTime;
+  change = clamp(change, -maxChange, maxChange);
+  target = current - change;
+  const temp = (velocityRef.value + omega * change) * deltaTime;
+  velocityRef.value = (velocityRef.value - omega * temp) * exp;
+  let output = target + (change + temp) * exp;
+  if ((originalTo - current > 0) === (output > originalTo)) {
+    output = originalTo;
+    velocityRef.value = (output - originalTo) / deltaTime;
+  }
+  return output;
+};
+
+export const lowPass = (current, target, smoothing, dt) => {
+  const alpha = 1 - Math.exp(-smoothing * dt);
+  return current + (target - current) * alpha;
+};
+
+export const average = (values) => values.reduce((a, b) => a + b, 0) / (values.length || 1);
+
+export const now = () => performance.now();
+
+export const sign = (value) => (value >= 0 ? 1 : -1);
+
+export const wrapDegrees = (deg) => {
+  let angle = deg;
+  while (angle > 180) angle -= 360;
+  while (angle < -180) angle += 360;
+  return angle;
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,462 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif;
+  --bg: #0f141c;
+  --panel: rgba(18, 24, 32, 0.88);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --accent: #52a8ff;
+  --accent-strong: #1e7aff;
+  --text: #f7fbff;
+  --text-dim: rgba(255, 255, 255, 0.7);
+  --danger: #ff4f6d;
+  --warning: #ffcc4d;
+  --safe-zone-inset: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  background: radial-gradient(circle at center, rgba(35, 48, 64, 0.95), #05070b 85%);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  overflow: hidden;
+}
+
+.app {
+  position: relative;
+  width: min(1200px, 100vw);
+  height: min(720px, 100vh);
+  padding: max(env(safe-area-inset-top), 12px) max(env(safe-area-inset-right), 12px) max(env(safe-area-inset-bottom), 12px) max(env(safe-area-inset-left), 12px);
+  display: grid;
+  grid-template-columns: 1fr min(340px, 38%);
+  grid-template-rows: 1fr;
+  gap: 14px;
+}
+
+.safe-area {
+  position: absolute;
+  inset: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  pointer-events: none;
+}
+
+.scene-container {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(12, 18, 28, 0.96), rgba(6, 8, 12, 0.96));
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+
+.scene-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background: radial-gradient(circle at 30% 30%, rgba(80, 96, 120, 0.12), rgba(0, 0, 0, 0.92));
+}
+
+.hud {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(12px, 2vw, 28px);
+  pointer-events: none;
+}
+
+.hud-row {
+  display: flex;
+  gap: clamp(10px, 2.5vw, 24px);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.hud-row.primary {
+  justify-content: space-between;
+}
+
+.hud-block {
+  background: rgba(12, 16, 22, 0.72);
+  border-radius: 12px;
+  padding: 10px 14px;
+  min-width: 110px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.hud-block .hud-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.hud-value {
+  display: block;
+  font-size: clamp(1rem, 2vw, 1.8rem);
+  font-weight: 600;
+}
+
+.hud-gear {
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.hud-trend::before {
+  content: attr(data-trend);
+  font-size: 1.2rem;
+  color: var(--accent);
+}
+
+.hud-row.secondary {
+  justify-content: flex-start;
+}
+
+.hud-indicator {
+  background: rgba(10, 14, 20, 0.66);
+  border-radius: 999px;
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  font-size: 0.85rem;
+  min-width: 54px;
+  text-align: center;
+  opacity: 0.25;
+  transition: opacity 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.hud-indicator.active {
+  opacity: 1;
+  background: rgba(82, 168, 255, 0.22);
+  color: var(--accent);
+}
+
+#hud-k.active {
+  background: rgba(255, 204, 77, 0.26);
+  color: var(--warning);
+}
+
+#hud-stop.active {
+  background: rgba(255, 79, 109, 0.26);
+  color: var(--danger);
+}
+
+.hud-bars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+}
+
+.hud-bar {
+  background: rgba(10, 12, 18, 0.6);
+  border-radius: 12px;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.bar-track {
+  position: relative;
+  height: 8px;
+  margin-top: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(30, 122, 255, 0.9), rgba(82, 168, 255, 0.4));
+  transition: width 0.12s ease;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(0, 1fr);
+  gap: 16px;
+  background: var(--panel);
+  border-radius: 18px;
+  border: 1px solid var(--panel-border);
+  padding: clamp(14px, 3vw, 22px);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+}
+
+.wheel-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.wheel-shadow {
+  position: absolute;
+  width: clamp(220px, 34vw, 320px);
+  height: clamp(220px, 34vw, 320px);
+  background: radial-gradient(circle, rgba(0, 0, 0, 0.35), transparent 70%);
+  filter: blur(28px);
+  top: clamp(10px, 2vw, 30px);
+  z-index: 0;
+}
+
+.wheel {
+  position: relative;
+  width: clamp(240px, 36vw, 340px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.12), rgba(15, 22, 32, 0.95));
+  border: 6px solid rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 6px 20px rgba(0, 0, 0, 0.6), 0 6px 20px rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  touch-action: none;
+  z-index: 1;
+  transition: box-shadow 0.15s ease;
+}
+
+.wheel:active {
+  cursor: grabbing;
+  box-shadow: inset 0 6px 28px rgba(0, 0, 0, 0.72), 0 10px 28px rgba(0, 0, 0, 0.52);
+}
+
+.wheel-center {
+  width: 32%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), rgba(20, 24, 30, 0.94));
+  border: 4px solid rgba(0, 0, 0, 0.6);
+}
+
+.wheel-spoke {
+  position: absolute;
+  width: 12%;
+  height: 50%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(0, 0, 0, 0.7));
+  border-radius: 999px;
+  top: 0;
+  left: 50%;
+  transform-origin: 50% 100%;
+}
+
+.spoke-0 {
+  transform: translateX(-50%) rotate(0deg);
+}
+
+.spoke-1 {
+  transform: translateX(-50%) rotate(120deg);
+}
+
+.spoke-2 {
+  transform: translateX(-50%) rotate(240deg);
+}
+
+.wheel-indicator {
+  font-size: 0.95rem;
+  color: var(--text-dim);
+}
+
+.wheel-settings {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px 0;
+}
+
+.wheel-settings label {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.wheel-settings select {
+  background: rgba(15, 22, 32, 0.9);
+  color: var(--text-primary);
+  border: 1px solid rgba(82, 168, 255, 0.32);
+  border-radius: 12px;
+  padding: 6px 20px;
+  font-size: 0.85rem;
+  min-width: 120px;
+  appearance: none;
+  text-align: center;
+  cursor: pointer;
+}
+
+.wheel-settings select:focus-visible {
+  outline: 2px solid rgba(82, 168, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.pedal-panel {
+  display: flex;
+  gap: clamp(16px, 2.8vw, 28px);
+  justify-content: center;
+  align-items: stretch;
+}
+
+.slider {
+  position: relative;
+  width: clamp(110px, 12vw, 132px);
+  min-width: 44px;
+  border-radius: 16px;
+  background: rgba(9, 12, 18, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 14px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+.slider-track {
+  position: relative;
+  width: 34%;
+  min-width: 44px;
+  height: 100%;
+  background: linear-gradient(180deg, rgba(26, 38, 52, 0.6), rgba(10, 14, 22, 0.9));
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.slider-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0%;
+  background: linear-gradient(180deg, rgba(30, 122, 255, 0.9), rgba(82, 168, 255, 0.35));
+  border-radius: 999px;
+  transition: height 0.1s ease;
+}
+
+.slider-handle {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max(56px, 7vw);
+  height: 56px;
+  border-radius: 18px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), rgba(15, 18, 24, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.slider-value {
+  pointer-events: none;
+}
+
+.slider-detent {
+  position: absolute;
+  left: 50%;
+  width: 90%;
+  transform: translateX(-50%);
+  height: 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.12);
+  opacity: 0.4;
+}
+
+.detent-pre {
+  top: 10%;
+}
+
+.detent-threshold {
+  top: 15%;
+  background: rgba(255, 79, 109, 0.35);
+}
+
+.detent-kickdown {
+  bottom: 13%;
+  height: 8px;
+  background: rgba(82, 168, 255, 0.45);
+}
+
+.camera-toggle {
+  position: absolute;
+  bottom: max(env(safe-area-inset-bottom), 24px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(12, 18, 28, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 12px 24px;
+  color: var(--text);
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
+}
+
+.camera-toggle:active {
+  transform: translateX(-50%) scale(0.97);
+}
+
+.touch-shield {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+@media (max-width: 1024px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+    height: 100vh;
+    width: 100vw;
+  }
+
+  .controls {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto 1fr;
+    align-items: center;
+  }
+
+  .pedal-panel {
+    width: 100%;
+    justify-content: space-evenly;
+  }
+
+  .camera-toggle {
+    position: fixed;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 14px;
+  }
+
+  .slider {
+    width: clamp(90px, 18vw, 120px);
+  }
+
+  .wheel {
+    width: clamp(200px, 70vw, 300px);
+  }
+}


### PR DESCRIPTION
## Summary
- add a configurable wheel lock selector with speed-aware recentering and spring-return brake/throttle inputs
- refine brake, retarder, and transmission kickdown behaviour to match intensity- and speed-dependent specs
- update audio, HUD, and documentation to reflect the new retarder and control dynamics

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df63935fd88330b27693ccffdd652a